### PR TITLE
[consent] add create transaction flag to consent to selfie verification

### DIFF
--- a/types.go
+++ b/types.go
@@ -5,10 +5,11 @@ import (
 )
 
 type CreateTransactionOptions struct {
-	CustomerUID string `json:"customer_uid"`
-	TemplateKey string `json:"template_key"`
-	Email       string `json:"email"`
-	Phone       string `json:"phone"`
+	CustomerUID                          string `json:"customer_uid"`
+	TemplateKey                          string `json:"template_key"`
+	Email                                string `json:"email"`
+	Phone                                string `json:"phone"`
+	ConsentsToAutomatedFacialRecognition string `json:"consents_to_automated_facial_recognition"`
 }
 
 type UpdateTransactionOptions struct {


### PR DESCRIPTION
Add support for setting the `ConsentsToAutomatedFacialRecognition` flag in go SDK for API only transactions. This is necessary to enable selfie verification for API only transactions.