### PR TITLE
[http] ensure error is returned

### DIFF
--- a/http.go
+++ b/http.go
@@ -54,7 +54,10 @@ func requestExpecting2XX(c HTTPClient, method string, url string, headers map[st
 		return err
 	}
 	defer func() {
-		err = res.Body.Close()
+		bodyCloseErr := res.Body.Close()
+		if err == nil && bodyCloseErr != nil {
+			err = bodyCloseErr
+		}
 	}()
 
 	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {


### PR DESCRIPTION
ensure error is returned when an http error from berbix occurs. We were incorrectly setting the `err` to nil based on the lack of `err` returned when closing the body.

Tested with unit tests and forcing 4xx by adding invalid json to payload. 