### PR TITLE
[nextstep] set nextStep to appropriate type

### DIFF
--- a/types.go
+++ b/types.go
@@ -225,7 +225,7 @@ type ImageUploadResult struct {
 
 type InvalidUploadForStateResponse struct {
 	// The next step to take given the current state.
-	NextStep string `json:"next_step"`
+	NextStep NextStep `json:"next_step"`
 	// A message describing the error to aid debugging
 	Message string `json:"message"`
 }


### PR DESCRIPTION
`NextStep` in `InvalidUploadForStateResponse` should be of type `NextStep` instead of string. 